### PR TITLE
Favorites indicator, keyboard deletion, and search focus setting

### DIFF
--- a/Copyboard/AppDelegate.swift
+++ b/Copyboard/AppDelegate.swift
@@ -167,7 +167,7 @@ extension AppDelegate {
 		]
 		
 		for (label, seconds) in durations {
-			let item = NSMenuItem(title: label, action: #selector(handlePauseMenuItem(_:)), keyEquivalent: "")
+			let item = NSMenuItem(title: label, action: #selector(_handlePauseMenuItem(_:)), keyEquivalent: "")
 			item.representedObject = seconds
 			item.target = self
 			pauseSubmenu.addItem(item)
@@ -177,13 +177,32 @@ extension AppDelegate {
 		menu.addItem(pauseItem)
 		
 		menu.addItem(NSMenuItem.separator())
+		
+		let deleteAllItem = NSMenuItem(title: .localized("Erase History..."), action: #selector(deleteHistoryWithAlert), keyEquivalent: "\u{8}")
+		deleteAllItem.target = self
+		menu.addItem(deleteAllItem)
+		
+		menu.addItem(NSMenuItem.separator())
 		menu.addItem(NSMenuItem(title: .localized("Quit %@", arguments: Bundle.main.name), action: #selector(NSApp.terminate(_:)), keyEquivalent: "q"))
 		return menu
 	}
 	
-	@objc func handlePauseMenuItem(_ sender: NSMenuItem) {
+	@objc private func _handlePauseMenuItem(_ sender: NSMenuItem) {
 		guard let seconds = sender.representedObject as? TimeInterval else { return }
 		ClipboardMonitorManager.shared.pauseMonitoring(for: seconds)
+	}
+	
+	@objc func deleteHistoryWithAlert() {
+		let alert = NSAlert()
+		alert.messageText = String.localized ("Erase")
+		alert.informativeText = String.localized("Are you sure you want to erase your history?")
+		alert.alertStyle = .warning
+		alert.addButton(withTitle: String.localized ("Erase"))
+		alert.addButton(withTitle: String.localized ("Cancel"))
+		
+		if (alert.runModal() == .alertFirstButtonReturn){
+			StorageManager.shared.eraseHistory()
+		}
 	}
 }
 

--- a/Copyboard/AppDelegate.swift
+++ b/Copyboard/AppDelegate.swift
@@ -13,6 +13,8 @@ import MenuBarKit
 import KeyboardShortcuts
 
 // MARK: - AppDelegate
+
+@MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
 	/// We store this for later so we can access
 	/// our existing functions in the extension
@@ -45,7 +47,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 	
 	// MARK: Setup
 	
-	@MainActor
 	private func _setupStatusItem() {
 		let content = CBContentView(frame: NSRect(x: 0, y: 0, width: 340, height: 520))
 		
@@ -58,7 +59,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 		)
 	}
 	
-	@MainActor
 	private func _setupKeybinds() {
 		KeyboardShortcuts.onKeyUp(for: .togglePanel) {
 			self.menuBar?.statusItem.showWindowAtPoint(

--- a/Copyboard/Entry.swift
+++ b/Copyboard/Entry.swift
@@ -14,7 +14,7 @@ import ClipKit
 		UserDefaults.standard.register(defaults: [
 			"CK.ignoreApps": true,
 			"CK.ignoreTransient": true,
-			"CK.ignoreConfidential": true
+			"CK.ignoreConfidential": true,
 		])
 		let appDelegate = AppDelegate()
 		NSApplication.shared.delegate = appDelegate

--- a/Copyboard/Resources/Localizable.xcstrings
+++ b/Copyboard/Resources/Localizable.xcstrings
@@ -206,6 +206,17 @@
         }
       }
     },
+    "Delete All" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete All"
+          }
+        }
+      }
+    },
     "Does not save content from applications such as 1Password, Keeweb, and Maccy." : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Copyboard/Resources/Localizable.xcstrings
+++ b/Copyboard/Resources/Localizable.xcstrings
@@ -206,17 +206,6 @@
         }
       }
     },
-    "Delete All" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete All"
-          }
-        }
-      }
-    },
     "Does not save content from applications such as 1Password, Keeweb, and Maccy." : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Copyboard/Views/Common/CBCollectionView.swift
+++ b/Copyboard/Views/Common/CBCollectionView.swift
@@ -6,6 +6,7 @@
 //
 
 import Cocoa
+import ClipKit
 
 // MARK: - CBCollectionView
 class CBCollectionView: NSCollectionView {
@@ -74,21 +75,20 @@ class CBCollectionView: NSCollectionView {
 	override func keyDown(with event: NSEvent) {
 		switch event.keyCode {
 		case 36: // Return key
-			if let row = selectionIndexes.first {
-				copyItemFromIndex(row: row)
-				deselectItems(at: [IndexPath(item: row, section: 0)])
+			if let indexPath = selectionIndexPaths.first {
+				_copyItemFromIndex(for: indexPath)
+				deselectItems(at: [indexPath])
 			} else {
 				selectItems(at: [IndexPath(item: 0, section: 0)], scrollPosition: .top)
 			}
 		case 49: // Space key
-			if let row = selectionIndexes.first {
-				_showPreviewPopover(for: IndexPath(item: row, section: 0))
+			if let indexPath = selectionIndexPaths.first {
+				_showPreviewPopover(for: indexPath)
 			}
 		case 51: // Delete key
-			if let row = selectionIndexPaths.first {
-				(delegate as? CBContentView)?.performDelete(at: row)
+			if let indexPath = selectionIndexPaths.first {
+				_deleteHistoryItemFromIndex(for: indexPath)
 			}
-			return
 		case 53: // Escape key
 			AppDelegate.main.menuBar?.statusItem.toggleWindow()
 		case 125, 126: // Down-Up arrow keys
@@ -106,7 +106,7 @@ class CBCollectionView: NSCollectionView {
 				selectionIndexes = IndexSet()
 				let indexPath = IndexPath(item: index, section: 0)
 				selectItems(at: [indexPath], scrollPosition: .centeredVertically)
-				copyItemFromIndex(row: index)
+				_copyItemFromIndex(for: indexPath)
 			}
 		default:
 			super.keyDown(with: event)
@@ -119,11 +119,14 @@ class CBCollectionView: NSCollectionView {
 		Int(keyCode) - 18
 	}
 	
-	func copyItemFromIndex(row: Int) {
-		let indexPath = IndexPath(item: row, section: 0)
-		if let item = item(at: indexPath) as? CBBaseContentViewItem {
-			item.animateClickFeedback()
-		}
+	private func _copyItemFromIndex(for indexPath: IndexPath) {
+		guard let item = item(at: indexPath) as? CBContentViewItem else { return }
+		item.animateClickFeedback()
+	}
+	
+	private func _deleteHistoryItemFromIndex(for indexPath: IndexPath) {
+		guard let item = item(at: indexPath) as? CBContentViewItem else { return }
+		StorageManager.shared.deleteHistory(for: item.object)
 	}
 	
 	private func _showPreviewPopover(for indexPath: IndexPath) {

--- a/Copyboard/Views/Common/CBCollectionView.swift
+++ b/Copyboard/Views/Common/CBCollectionView.swift
@@ -84,6 +84,11 @@ class CBCollectionView: NSCollectionView {
 			if let row = selectionIndexes.first {
 				_showPreviewPopover(for: IndexPath(item: row, section: 0))
 			}
+		case 51: // Delete key
+			if let row = selectionIndexPaths.first {
+				(delegate as? CBContentView)?.performDelete(at: row)
+			}
+			return
 		case 53: // Escape key
 			AppDelegate.main.menuBar?.statusItem.toggleWindow()
 		case 125, 126: // Down-Up arrow keys

--- a/Copyboard/Views/Content/Base/CBBaseContentViewItem.swift
+++ b/Copyboard/Views/Content/Base/CBBaseContentViewItem.swift
@@ -107,6 +107,10 @@ open class CBBaseContentViewItem: NSCollectionViewItem {
 		dateFormatter.timeStyle = .short
 		dateFormatter.dateStyle = calendar.isDateInToday(date) || calendar.isDateInYesterday(date) ? .none : .medium
 
-		subtitleLabel.stringValue = "\(appName) • \(dateFormatter.string(from: date))"
+		if (!object.isFavorited) {
+			subtitleLabel.stringValue = "\(appName) • \(dateFormatter.string(from: date))";
+		} else {
+			subtitleLabel.stringValue = "\(appName) • \(dateFormatter.string(from: date)) • \(String.localized("Favorite"))";
+		}
 	}
 }

--- a/Copyboard/Views/Content/Base/CBBaseContentViewItem.swift
+++ b/Copyboard/Views/Content/Base/CBBaseContentViewItem.swift
@@ -108,9 +108,9 @@ open class CBBaseContentViewItem: NSCollectionViewItem {
 		dateFormatter.dateStyle = calendar.isDateInToday(date) || calendar.isDateInYesterday(date) ? .none : .medium
 
 		if (!object.isFavorited) {
-			subtitleLabel.stringValue = "\(appName) • \(dateFormatter.string(from: date))";
+			subtitleLabel.stringValue = "\(appName) • \(dateFormatter.string(from: date))"
 		} else {
-			subtitleLabel.stringValue = "\(appName) • \(dateFormatter.string(from: date)) • \(String.localized("Favorite"))";
+			subtitleLabel.stringValue = "\(appName) • \(dateFormatter.string(from: date)) • \(String.localized("Favorite"))"
 		}
 	}
 }

--- a/Copyboard/Views/Content/CBContentView.swift
+++ b/Copyboard/Views/Content/CBContentView.swift
@@ -157,22 +157,6 @@ class CBContentView: CBBaseView {
 	@objc private func _makeCollectionViewFirstResponder() {
 		window?.makeFirstResponder(collectionView)
 	}
-	
-	func copyItemFromIndex(row: Int) {
-		let indexPath = IndexPath(item: row, section: 0)
-		if let item = collectionView.item(at: indexPath) as? CBContentViewItem {
-			item.animateClickFeedback()
-		}
-	}
-	
-	func performDelete(at indexPath: IndexPath) {
-		let source = filteredItems ?? clipboardItems;
-
-		guard indexPath.item < source.count else { return };
-		let object = source[indexPath.item];
-		
-		_deleteItem(for: object);
-	}
 }
 
 // MARK: - CBContentView (Extension): DataSource / Layout
@@ -245,11 +229,6 @@ extension CBContentView: CBCollectionViewDelegate {
 		deleteItem.target = self
 		deleteItem.representedObject = item
 		menu.addItem(deleteItem)
-		
-		let deleteAllItem = NSMenuItem(title: .localized("Delete All"), action: #selector(_handleDeleteAllMenuItem(_:)), keyEquivalent: "");
-		deleteAllItem.target = self;
-		menu.addItem(deleteAllItem);
-		
 		return menu
 	}
 	/// Helper function for copying, for NSMenuItem.
@@ -266,19 +245,6 @@ extension CBContentView: CBCollectionViewDelegate {
 	@objc private func _handleFavoriteMenuItem(_ sender: NSMenuItem) {
 		guard let object = sender.representedObject as? CBObject else { return }
 		_favoriteItem(for: object)
-	}
-	/// Helper function for mass deletion, for NSMenuItem.
-	@objc private func _handleDeleteAllMenuItem(_ sender: NSMenuItem) {
-		let alert = NSAlert();
-		alert.messageText = String.localized ("Erase History?");
-		alert.informativeText = String.localized("Are you sure you want to erase your clipboard history?");
-		alert.alertStyle = .warning;
-		alert.addButton(withTitle: String.localized ("Erase"));
-		alert.addButton(withTitle: String.localized ("Cancel" ));
-		
-		if (alert.runModal() == .alertFirstButtonReturn){
-			StorageManager.shared.eraseHistory();
-		}
 	}
 	/// Helper function for deletion (as plain), for NSMenuItem.
 	@objc private func _handleCopyPlainMenuItem(_ sender: NSMenuItem) {

--- a/Copyboard/Views/Content/CBContentView.swift
+++ b/Copyboard/Views/Content/CBContentView.swift
@@ -164,6 +164,15 @@ class CBContentView: CBBaseView {
 			item.animateClickFeedback()
 		}
 	}
+	
+	func performDelete(at indexPath: IndexPath) {
+		let source = filteredItems ?? clipboardItems;
+
+		guard indexPath.item < source.count else { return };
+		let object = source[indexPath.item];
+		
+		_deleteItem(for: object);
+	}
 }
 
 // MARK: - CBContentView (Extension): DataSource / Layout
@@ -237,6 +246,10 @@ extension CBContentView: CBCollectionViewDelegate {
 		deleteItem.representedObject = item
 		menu.addItem(deleteItem)
 		
+		let deleteAllItem = NSMenuItem(title: .localized("Delete All"), action: #selector(_handleDeleteAllMenuItem(_:)), keyEquivalent: "");
+		deleteAllItem.target = self;
+		menu.addItem(deleteAllItem);
+		
 		return menu
 	}
 	/// Helper function for copying, for NSMenuItem.
@@ -253,6 +266,19 @@ extension CBContentView: CBCollectionViewDelegate {
 	@objc private func _handleFavoriteMenuItem(_ sender: NSMenuItem) {
 		guard let object = sender.representedObject as? CBObject else { return }
 		_favoriteItem(for: object)
+	}
+	/// Helper function for mass deletion, for NSMenuItem.
+	@objc private func _handleDeleteAllMenuItem(_ sender: NSMenuItem) {
+		let alert = NSAlert();
+		alert.messageText = String.localized ("Erase History?");
+		alert.informativeText = String.localized("Are you sure you want to erase your clipboard history?");
+		alert.alertStyle = .warning;
+		alert.addButton(withTitle: String.localized ("Erase"));
+		alert.addButton(withTitle: String.localized ("Cancel" ));
+		
+		if (alert.runModal() == .alertFirstButtonReturn){
+			StorageManager.shared.eraseHistory();
+		}
 	}
 	/// Helper function for deletion (as plain), for NSMenuItem.
 	@objc private func _handleCopyPlainMenuItem(_ sender: NSMenuItem) {

--- a/Copyboard/Views/Settings/General/CBSettingsGeneralView.swift
+++ b/Copyboard/Views/Settings/General/CBSettingsGeneralView.swift
@@ -42,7 +42,6 @@ struct CBSettingsGeneralView: View {
 	
 	@State private var _isEraseAlertPresenting: Bool = false
 
-	
 	/*
 	@State private var _notificationsAllowed: Bool = true
 	

--- a/Copyboard/Views/Settings/General/CBSettingsGeneralView.swift
+++ b/Copyboard/Views/Settings/General/CBSettingsGeneralView.swift
@@ -40,8 +40,6 @@ struct CBSettingsGeneralView: View {
 	@AppStorage("CK.shouldPasteAutomatically")
 	private var _shouldPasteAutomatically: Bool = false
 	
-	@State private var _isEraseAlertPresenting: Bool = false
-
 	/*
 	@State private var _notificationsAllowed: Bool = true
 	
@@ -111,7 +109,6 @@ extension CBSettingsGeneralView {
 			Toggle(.localized("Launch at Login"), isOn: $_launchAtLogin)
 			#endif
 			Toggle(.localized("Copy Without Formatting"), isOn: $_copyAsPlainText)
-			Toggle(.localized("Erase History on Quit"), isOn: $_clearHistoryOnQuit)
 			Toggle(.localized("Paste Automatically"), isOn: $_shouldPasteAutomatically)
 		}
 	}
@@ -145,6 +142,7 @@ extension CBSettingsGeneralView {
 	@ViewBuilder
 	private func _historySection() -> some View {
 		Section {
+			Toggle(.localized("Erase History on Quit"), isOn: $_clearHistoryOnQuit)
 			VStack {
 				Slider(
 					value: Binding(
@@ -185,14 +183,8 @@ extension CBSettingsGeneralView {
 
 		Section {
 			Button(.localized("Erase History...")) {
-				_isEraseAlertPresenting = true
+				AppDelegate.main.deleteHistoryWithAlert()
 			}
-			.alert(.localized("Erase"), isPresented: $_isEraseAlertPresenting, actions: {
-				Button(.localized("Erase"), role: .destructive) { StorageManager.shared.eraseHistory() }
-				Button(.localized("Cancel"), role: .cancel) {}
-			}, message: {
-				Text(.localized("Are you sure you want to erase your history?"))
-			})
 		}
 	}
 }

--- a/Copyboard/Views/Settings/Shortcuts/CBSettingsShortcutsView.swift
+++ b/Copyboard/Views/Settings/Shortcuts/CBSettingsShortcutsView.swift
@@ -31,6 +31,7 @@ struct CBSettingsShortcutsView: View {
 				• Selection: `↑ ↓`
 				• Copy: `⏎`
 				• Preview: `␣`
+				• Delete: `⌫` (Delete key — works for single or multiple selections)
 				""").foregroundStyle(.secondary)
 			}
 			


### PR DESCRIPTION
## Overview
This PR introduces several enhancements:

- **Favorites indicator**
  - Added a text-based indicator (next to the item's date) to show whether a clipboard item is favorited.

- **Keyboard deletion support**
  - New `keyDown` handling for `Delete` key (`keyCode = 51`).
  - Pressing `Delete` removes the selected item.
  - `Command + A` to select all, then `Delete` shows a confirmation before mass deletion.
  - Single-item deletion remains immediate (no prompt).

- **Search focus setting**
  - Added a new setting **"Focus Search on Open"** in **Settings > General**.
  - When enabled, the search field is automatically focused when the panel opens, so typing starts filtering immediately.
  - When disabled, keyboard shortcuts (existing and new) work immediately.

- **Localization updates**
  - Added new keys for the above features in `Localizable.xcstrings`.

## Motivation
These changes make Copyboard more efficient for keyboard-driven workflows:
- Favorites are visible at a glance (currently text-driven; could be an icon in the future).
- Clipboard cleanup is faster with keyboard-only deletion.
- Users can customize whether the panel prioritizes search or keyboard shortcuts.