### PR TITLE
Copyboard(Content): fix certain search bar events to the collection view instead (#3)

### DIFF
--- a/Copyboard/Views/Common/CBSearchField.swift
+++ b/Copyboard/Views/Common/CBSearchField.swift
@@ -39,11 +39,11 @@ class CBSearchField: NSSearchField {
 		focusRingType = .none
 	}
 	override func becomeFirstResponder() -> Bool {
-			if let editor = self.currentEditor() {
-				editor.delegate = self
-			}
-			return super.becomeFirstResponder()
+		if let editor = self.currentEditor() {
+			editor.delegate = self
 		}
+		return super.becomeFirstResponder()
+	}
 }
 
 extension CBSearchField: NSTextViewDelegate {
@@ -94,6 +94,22 @@ extension CBSearchField: NSTextViewDelegate {
 					 charactersIgnoringModifiers: "",
 					 isARepeat: false,
 					 keyCode: 53
+				)!)
+			}
+			return true
+		case #selector(NSResponder.insertNewline(_:)):
+			if let content = self.superview?.superview as? CBContentView {
+				content.collectionView.keyDown(with: NSEvent.keyEvent(
+					 with: .keyDown,
+					 location: NSPoint(x: 0, y: 0),
+					 modifierFlags: [],
+					 timestamp: ProcessInfo.processInfo.systemUptime,
+					 windowNumber: 0,
+					 context: nil,
+					 characters: "\n",
+					 charactersIgnoringModifiers: "\n",
+					 isARepeat: false,
+					 keyCode: 36
 				)!)
 			}
 			return true

--- a/Copyboard/Views/Common/CBSearchField.swift
+++ b/Copyboard/Views/Common/CBSearchField.swift
@@ -38,4 +38,67 @@ class CBSearchField: NSSearchField {
 		
 		focusRingType = .none
 	}
+	override func becomeFirstResponder() -> Bool {
+			if let editor = self.currentEditor() {
+				editor.delegate = self
+			}
+			return super.becomeFirstResponder()
+		}
+}
+
+extension CBSearchField: NSTextViewDelegate {
+	func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+		switch commandSelector {
+		case #selector(NSResponder.moveUp(_:)):
+			if let content = self.superview?.superview as? CBContentView {
+				content.collectionView.keyDown(with: NSEvent.keyEvent(
+					 with: .keyDown,
+					 location: .zero,
+					 modifierFlags: [],
+					 timestamp: ProcessInfo.processInfo.systemUptime,
+					 windowNumber: 0,
+					 context: nil,
+					 characters: "",
+					 charactersIgnoringModifiers: "",
+					 isARepeat: false,
+					 keyCode: 126
+				)!)
+			}
+			return true
+		case #selector(NSResponder.moveDown(_:)):
+			if let content = self.superview?.superview as? CBContentView {
+				content.collectionView.keyDown(with: NSEvent.keyEvent(
+					 with: .keyDown,
+					 location: NSPoint(x: 0, y: 0),
+					 modifierFlags: [],
+					 timestamp: ProcessInfo.processInfo.systemUptime,
+					 windowNumber: 0,
+					 context: nil,
+					 characters: "",
+					 charactersIgnoringModifiers: "",
+					 isARepeat: false,
+					 keyCode: 125
+				)!)
+			}
+			return true
+		case #selector(NSResponder.cancelOperation(_:)):
+			if let content = self.superview?.superview as? CBContentView {
+				content.collectionView.keyDown(with: NSEvent.keyEvent(
+					 with: .keyDown,
+					 location: NSPoint(x: 0, y: 0),
+					 modifierFlags: [],
+					 timestamp: ProcessInfo.processInfo.systemUptime,
+					 windowNumber: 0,
+					 context: nil,
+					 characters: "",
+					 charactersIgnoringModifiers: "",
+					 isARepeat: false,
+					 keyCode: 53
+				)!)
+			}
+			return true
+		default:
+			return false
+		}
+	}
 }


### PR DESCRIPTION
## Description
Using `NSTextViewDelegate` and `textView(_ textView: NSTextView, doCommandBy commandSelector: Selector)`, the when the moveUp, moveDown, and cancelOperation commands are trigged, keyDown on the collection view is called to emulate the missing NSEvent when the search bar is focused.